### PR TITLE
Remove `version` from docker-compose.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -636,7 +636,6 @@ The Docker container will run the `main.py` script every 24 hours to back up Bit
 
 ``` YAML
 
-version: "3.3"
 services:
   lazywarden:
     container_name: lazywarden_backup

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.3"
 services:
   lazywarden:
     container_name: lazywarden_backup


### PR DESCRIPTION
When running the container via the `docker-compose.yml` this error is given:

`the attribute version is obsolete, it will be ignored, please remove it to avoid potential confusion`

[Reference in the compose-spec](https://github.com/compose-spec/compose-spec/blob/main/spec.md#version-and-name-top-level-elements)