### PR TITLE
Enable Shared Drive functionality for Google Drive backups

### DIFF
--- a/app/backup.py
+++ b/app/backup.py
@@ -162,7 +162,12 @@ def create_folder_if_not_exists(drive_service, folder_name, parent_folder_id=Non
     query = f"name = '{folder_name}' and mimeType = 'application/vnd.google-apps.folder'"
     if parent_folder_id:
         query += f" and '{parent_folder_id}' in parents"
-    results = drive_service.files().list(q=query, fields="files(id, name)").execute()
+    results = drive_service.files().list(
+        q=query,
+        includeItemsFromAllDrives=True,
+        supportsAllDrives=True,
+        fields="files(id, name)"
+    ).execute()
     items = results.get('files', [])
     if not items:
         folder_metadata = {
@@ -173,6 +178,7 @@ def create_folder_if_not_exists(drive_service, folder_name, parent_folder_id=Non
         try:
             created_folder = drive_service.files().create(
                 body=folder_metadata,
+                supportsAllDrives=True,
                 fields='id'
             ).execute()
             logging.info(f"{Fore.GREEN}Created Folder ID: {created_folder['id']}")
@@ -202,7 +208,12 @@ def upload_file_to_drive(drive_service, file_path, folder_id):
     }
     media = MediaFileUpload(file_path, resumable=True)
     try:
-        file = drive_service.files().create(body=file_metadata, media_body=media, fields='id').execute()
+        file = drive_service.files().create(
+            body=file_metadata,
+            media_body=media,
+            supportsAllDrives=True,
+            fields='id'
+        ).execute()
         logging.info(f"{Fore.GREEN}File ID: {file.get('id')}")
     except Exception as e:
         logging.error(f"{Fore.RED}Error uploading file to Drive: {e}")


### PR DESCRIPTION
The current Google Drive backup code does not allow for a folder that is stored on a Workspace Shared Drive.

Currently, if a Shared Drive Folder ID is specified, the following errors are thrown.

`Error creating folder: <HttpError 404 when requesting https://www.googleapis.com/drive/v3/files?fields=id&alt=json returned "File not found: <Folder ID>.". Details: "[{'message': 'File not found: <Folder ID>.', 'domain': 'global', 'reason': 'notFound', 'location': 'fileId', 'locationType': 'parameter'}]">`
`Error uploading to Google Drive: <HttpError 404 when requesting https://www.googleapis.com/drive/v3/files?fields=id&alt=json returned "File not found: <Folder ID>.". Details: "[{'message': 'File not found: <Folder ID>.', 'domain': 'global', 'reason': 'notFound', 'location': 'fileId', 'locationType': 'parameter'}]">`

This can be enabled through the existing Google API Client library by adding the `includeItemsFromAllDrives=True` and `supportsAllDrives=True` parameters to the `files().list` method and adding the `supportsAllDrives=True` parameter to the `files().create` methods.

Reference:
- https://developers.google.com/drive/api/reference/rest/v3/files/list
- https://developers.google.com/drive/api/reference/rest/v3/files/create

